### PR TITLE
Missing out from second Deconstruct method

### DIFF
--- a/snippets/csharp/programming-guide/deconstructing-tuples/deconstruct-ambiguous.cs
+++ b/snippets/csharp/programming-guide/deconstructing-tuples/deconstruct-ambiguous.cs
@@ -21,7 +21,7 @@ public class Person
          age--;
    }
 
-   public void Deconstruct(out string lname, out string fname, out string mname, decimal income)
+   public void Deconstruct(out string lname, out string fname, out string mname, out decimal income)
    {
       fname = FirstName;
       mname = MiddleName;


### PR DESCRIPTION
The second Deconstruct method was missing an `out` before the last parameter `decimal income`.